### PR TITLE
Set current to 0 if charging is not allowed in case of stop or standby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# hdec -- Ein Python Modul für die Wallbox "Heidelberg Energy Control"
-<small>english version: see below</small>
-
-THIS IS A BIT REWORKED VERSION OF THE ORIGINAL VERSION 
+**THIS IS A BIT REWORKED VERSION OF THE ORIGINAL VERSION**
 
 The following things have been added:
 - MQTT support for integration with EVCC
@@ -16,6 +13,9 @@ Setting up MQTT commands in EVCC, follow this guide here: https://github.com/ste
 Only 1 wallbox supported. Let me know if one requires additional features. Feedback welcome.
 
 ORIGINAL TEXT:
+
+# hdec -- Ein Python Modul für die Wallbox "Heidelberg Energy Control"
+<small>english version: see below</small>
 
 Das Ziel dieses Moduls ist es, die Wallbox "Heidelberg Energy Control" über 
 deren Modbus zu steuern. Insbesondere geht es darum, ein Lademodul für openWB 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ werden, "leader" ist dann der Raspi.
 ### Das Modul einrichten
 ```
 cd /tmp
-git clone https://github.com/leuzoe/hdec
+git clone https://github.com/oldgitdaddy/hdec
 cd /var/www
 sudo mkdir hdec
 sudo chown pi hdec
@@ -198,7 +198,7 @@ box must be configured to be a "follower". Modbus "leader" is your raspi.
 ### Install the module
 ```
 cd /tmp
-git clone https://github.com/leuzoe/hdec
+git clone https://github.com/oldgitdaddy/hdec
 cd /var/www
 sudo mkdir hdec
 sudo chown pi hdec

--- a/src/hdecserver.py
+++ b/src/hdecserver.py
@@ -63,6 +63,8 @@ class MyServer(BaseHTTPRequestHandler):
             if(cmd[0] == 'alw'):
                 self.wb.allow(cmd[1] != "0")
                 res = True
+                if(cmd[1] == "0"):
+                    self.wb.set_current_preset(0)
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             data = '{' + \


### PR DESCRIPTION
Löste bei mir folgendes Problem: https://github.com/leuzoe/hdec/issues/4

OpenWB 1.9 setzt nur allowed = 0, aber keine Stromstärke. Meine Heidelberg-Wallbox reagiert damit nicht auf Stop oder Standby.